### PR TITLE
Fix: stop using CID as ref for STORE messages

### DIFF
--- a/src/request_alephim_store/aleph.py
+++ b/src/request_alephim_store/aleph.py
@@ -1,4 +1,5 @@
-    
+from typing import Any, Dict, Optional
+
 from aleph_client.asynchronous import create_store
 from aleph_client.chains.ethereum import ETHAccount
 from functools import lru_cache
@@ -23,7 +24,7 @@ async def get_previous_stored(session, cid):
         settings.aleph_api_server
     ), params={
         "msgType": "STORE",
-        "refs": cid, 
+        "refs": f"request-{cid}",
         "address": get_aleph_address(),
         "channels": settings.aleph_channel
     }) as resp:
@@ -34,7 +35,7 @@ async def get_previous_stored(session, cid):
             return None
 
 
-async def create_storage(session, ref, content, context):
+async def create_storage(content: str, context: Dict[str, Any], ref: Optional[str] = None):
     LOGGER.debug(f"Preparing STORE item for {ref} on height {context['height']}")
     store = await create_store(
         get_aleph_account(),

--- a/src/request_alephim_store/request.py
+++ b/src/request_alephim_store/request.py
@@ -36,7 +36,7 @@ async def handle_cid(session, context, cid):
             return
         # await ipfs_push_file(io.StringIO(cid_content),
         #                      api_server=settings.aleph_api_server)
-        await create_storage(session, cid, cid_content, context)
+        await create_storage(content=cid_content, context=context, ref=f"request-{cid}")
     else:
         ALREADY_HANDLED.add(cid)
         LOGGER.debug("{} Already handled".format(context["height"]))


### PR DESCRIPTION
Problem: using a CID as reference is now taken into account by the message processing dependency resolution system and interpreted as the hash of a STORE message to update. As we use the CID of the file, a corresponding aleph.im message never exists and the message is discarded.

Solution: set the ref field to None.